### PR TITLE
fix: Keyword.keys()

### DIFF
--- a/lib/ouroboros/ecto/query.ex
+++ b/lib/ouroboros/ecto/query.ex
@@ -92,7 +92,7 @@ defmodule Ouroboros.Ecto.Query do
   defp filter_values(query, fields, values, cursor_direction) do
     sorts =
       fields
-      |> Keyword.keys()
+      |> Enum.map(&elem(&1, 0))
       |> Enum.zip(values)
       |> Enum.reject(fn val -> match?({_column, nil}, val) end)
 

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -4,7 +4,10 @@ defmodule Ouroboros.Repo do
 
   def init(_type, config) do
     {:ok, Keyword.merge(config, [
+      username: "postgres",
+      password: "postgres",
       database: "ouroboros_db",
+      hostname: "localhost",
       pool: Ecto.Adapters.SQL.Sandbox
     ])}
   end


### PR DESCRIPTION
Keyword.keys() cannot be used for non-keyword lists from Elixir 1.11